### PR TITLE
First draft db/admin setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
- FROM python:3.6.1
- ENV PYTHONUNBUFFERED 1
- RUN mkdir /perma-payments
- WORKDIR /perma-payments
- ADD perma-payments/ /perma-payments/
- RUN pip install -r requirements.txt
+FROM python:3.6.1
+ENV PYTHONUNBUFFERED 1
+RUN mkdir /perma-payments
+WORKDIR /perma-payments
+ADD perma-payments/requirements.txt /perma-payments/
+RUN pip install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 1. Install Docker (https://www.docker.com/community-edition). @rebeccacremona currently prefers Docker Tookbox (https://www.docker.com/products/docker-toolbox) due to certain performance issues when automatically re-building the [LIL website](https://github.com/harvard-lil/website-static); your mileage may vary.
 
-2. We use [Fabric](http://www.fabfile.org/) to automate common tasks. Recommended: add the following alias to your .bash_profile or similar, so that it's easier run fabric tasks inside the Docker container.
+2. We use [Fabric](http://www.fabfile.org/) to automate common tasks. Recommended: add the following alias to your .bash_profile or similar, so that `dfab` will run any arbitrary fabric task inside the Docker container.
 `alias dfab="docker-compose exec web fab"`
 
 3. Clone the repo and cd inside
@@ -15,19 +15,19 @@
     -  a "db" container with a postgres database
     -  a "web" container with python, Django, and the rest of our dev environment.
 
-5. Run `dfab run` to start the Django development server.
+5. Run `dfab init_db` to initialize a development database.
+
+6. Run `dfab run` to start the Django development server.
     -  If you are using Docker for Mac, the app will be served at http://localhost:8000
     -  If you are running Docker Machine, run `docker-machine ip` to discover the IP address of your virtualbox. The app will be served at http://#.#.#.#:8000
 
-  Other fabric tasks (e.g. `fab test`, `fab init_db`) can similarly be run using `dfab`.
+To stop all running containers (and retain any information in your database), run `docker-compose stop`.
 
-To get to a bash terminal in the running docker container, run `docker-compose exec web bash`.
-
-To stop all running containers, run `docker-compose stop`.
-
-To stop and remove all containers created via docker-compose up, run `docker-compose down`.
+To stop and destroy all containers created via docker-compose up, run `docker-compose down`. Note that this will destroy your database and all its data.
 
 If you need to start fresh for some reason, run `docker-compose down --rmi local`.
+
+To get to a bash terminal in the running docker container, run `docker-compose exec web bash`.
 
 If you change the contents of docker-compose.yml, running `docker-compose up -d` again should cause your changes to get picked up.
 

--- a/perma-payments/config/settings/settings_base.py
+++ b/perma-payments/config/settings/settings_base.py
@@ -113,3 +113,5 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/1.11/howto/static-files/
 
 STATIC_URL = '/static/'
+
+ADMIN_ENABLED = False

--- a/perma-payments/config/settings/settings_dev.py
+++ b/perma-payments/config/settings/settings_dev.py
@@ -7,3 +7,5 @@ SECRET_KEY = 'k2#@_q=1$(__n7#(zax6#46fu)x=3&^lz&bwb8ol-_097k_rj5'
 DEBUG = True
 
 ALLOWED_HOSTS = ['*']
+
+ADMIN_ENABLED = True

--- a/perma-payments/config/urls.py
+++ b/perma-payments/config/urls.py
@@ -13,10 +13,15 @@ Including another URLconf
     1. Import the include() function: from django.conf.urls import url, include
     2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
 """
+from django.conf import settings
 from django.conf.urls import include, url
 from django.contrib import admin
 
-urlpatterns = [
-    url(r'^admin/', admin.site.urls),
+urlpatterns = []
+
+if settings.ADMIN_ENABLED:
+    urlpatterns.extend([url(r'^admin/', admin.site.urls)])
+
+urlpatterns.extend([
     url(r'^', include('perma_payments.urls'))
-]
+])

--- a/perma-payments/fabfile.py
+++ b/perma-payments/fabfile.py
@@ -7,9 +7,9 @@ try:
 except Exception as e:
     print("WARNING: Can't configure Django -- tasks depending on Django will fail:\n%s" % e)
 
-from django.contrib.auth.models import User
 from fabric.api import local
 from fabric.decorators import task
+from django.conf import settings
 
 @task(alias='run')
 def run_django():
@@ -22,8 +22,10 @@ def test():
 @task
 def init_db():
     """
-        Set up new dev database.
+        Set up a new dev database.
     """
     local("python3 manage.py migrate")
-    print("Creating DEV admin user:")
-    User.objects.create_superuser('admin', 'admin@example.com', 'admin')
+    if settings.ADMIN_ENABLED:
+        print("Creating dev admin user.")
+        from django.contrib.auth.models import User #noqa
+        User.objects.create_superuser('admin', 'admin@example.com', 'admin')


### PR DESCRIPTION
Note:

Routes to the Django admin are loaded, and a dev super user is created, only if ADMIN_ENABLED = True, which is False by default and is overridden in settings_dev.

We could also add 'django.contrib.admin' to INSTALLED_APPS only in settings_dev, if we want to be extra careful. Not making this move for now.