### PR TITLE
Cancellations are hard

### DIFF
--- a/perma-payments/perma_payments/views.py
+++ b/perma-payments/perma_payments/views.py
@@ -370,7 +370,7 @@ def subscription(request):
             'paid_through': standing_subscription.paid_through
         }
 
-        if standing_subscription.cancellation_requested:
+        if standing_subscription.cancellation_requested and standing_subscription.status != 'Canceled':
             subscription['status'] = 'Cancellation Requested'
         else:
             subscription['status'] = standing_subscription.status


### PR DESCRIPTION
If someone "cancels their subscription", that essentially means "auto-renew = off." They should be able to make Permalinks through their "paid_through" date. And, they shouldn't be able to sign up for another subscription until after their "paid_through" date has passed. (It'd be nice if there was, like, an "uncancel" option that lets them toggle at will, but that's way way way stretch.)

For all that to work, we need to count SubscriptionAgreements w/ status = 'Canceled' and paid_through date equal to or after today as "standing." And, we need to send appropriate information about canceled-but-still-paid-up subscriptions to Perma via the /subscription route.