### PR TITLE
Better handling of email.

### DIFF
--- a/perma-payments/config/settings/settings_base.py
+++ b/perma-payments/config/settings/settings_base.py
@@ -67,6 +67,13 @@ TEMPLATES = [
         },
     },
 ]
+# Add a second, identical template engine except with autoescape off,
+# for use when rendering non-HTML templates.
+# Use by passing 'using='AUTOESCAPE_OFF' to render or render_to_string.
+off = TEMPLATES[0].copy()
+off['NAME'] = 'AUTOESCAPE_OFF'
+off['OPTIONS']['autoescape'] = False
+TEMPLATES.append(off)
 
 WSGI_APPLICATION = 'config.wsgi.application'
 
@@ -126,7 +133,10 @@ STATIC_URL = '/static/'
 # Email
 DEFAULT_FROM_EMAIL = 'info@perma.cc'
 DEFAULT_CONTACT_EMAIL = DEFAULT_FROM_EMAIL
+# in production, DEFAULT_REPLYTO_EMAIL and DEFAULT_FROM must be different
+DEFAULT_REPLYTO_EMAIL = DEFAULT_FROM_EMAIL
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+
 
 # Admin
 ADMIN_ENABLED = False

--- a/perma-payments/config/settings/settings_testing.py
+++ b/perma-payments/config/settings/settings_testing.py
@@ -29,3 +29,7 @@ PERMA_ENCRYPTION_KEYS = {
     'perma_public_key': 'ZmkWU6AdQlNrDCLNI154HSGH96jjs21UA3K+YpqezWg=',
 }
 PERMA_TIMESTAMP_MAX_AGE_SECONDS = 120
+
+ADMINS = (
+    ("Admin's Name", 'admin@example.com'),
+)

--- a/perma-payments/fabfile.py
+++ b/perma-payments/fabfile.py
@@ -38,15 +38,14 @@ def find_pending_cancellation_requests():
     Report pending cancellation requests.
     """
     from perma_payments.constants import CS_SUBSCRIPTION_SEARCH_URL #noqa
-    from perma_payments.email import send_admin_email #noqa
+    from perma_payments.email import send_self_email #noqa
     from perma_payments.models import SubscriptionAgreement #noqa
     from django.test.client import RequestFactory #noqa
 
     sas = SubscriptionAgreement.objects.filter(cancellation_requested=True).exclude(status='Canceled')
     if len(sas) == 0:
-        send_admin_email(
+        send_self_email(
             'No cancellation requests pending',
-            settings.DEFAULT_FROM_EMAIL,
             RequestFactory().get('this-is-a-placeholder-request'),
             context={
                 'message': "Congrats, no cancellation requests pending today. ~ Perma Payments"
@@ -60,9 +59,8 @@ def find_pending_cancellation_requests():
                 'status': sa.status
             } for sa in sas
         ]
-        send_admin_email(
+        send_self_email(
             'ACTION REQUIRED: cancellation requests pending',
-            settings.DEFAULT_FROM_EMAIL,
             RequestFactory().get('this-is-a-placeholder-request'),
             template="email/cancellation_report.txt",
             context={
@@ -72,5 +70,6 @@ def find_pending_cancellation_requests():
                 'registrar_users_path': settings.REGISTRAR_USERS_PATH,
                 'total': len(data),
                 'requests': data
-            }
+            },
+            devs_only=False
         )

--- a/perma-payments/perma_payments/email.py
+++ b/perma-payments/perma_payments/email.py
@@ -22,5 +22,5 @@ def send_self_email(title, request, template="email/default.txt", context={}, de
             render_to_string(template, context=context, request=request, using="AUTOESCAPE_OFF"),
             settings.DEFAULT_FROM_EMAIL,
             [settings.DEFAULT_FROM_EMAIL],
-            headers={'Reply-To': settings.DEFAULT_REPLYTO_EMAIL}
+            reply_to=[settings.DEFAULT_REPLYTO_EMAIL]
         ).send(fail_silently=False)

--- a/perma-payments/perma_payments/email.py
+++ b/perma-payments/perma_payments/email.py
@@ -3,15 +3,24 @@ from django.core.mail import EmailMessage
 from django.template.loader import render_to_string
 
 
-def send_admin_email(title, from_address, request, template="email/default.txt", context={}):
+def send_self_email(title, request, template="email/default.txt", context={}, devs_only=True):
     """
-    Send a message on behalf of a user to the admins.
-    Use reply-to for the user address so we can use email services that require authenticated from addresses.
+        Send a message to ourselves. By default, sends only to settings.ADMINS.
+        To contact the main Perma email address, set devs_only=False
     """
-    EmailMessage(
-        title,
-        render_to_string(template, context=context, request=request),
-        settings.DEFAULT_FROM_EMAIL,
-        [settings.DEFAULT_FROM_EMAIL],
-        reply_to=[from_address]
-    ).send(fail_silently=False)
+    if devs_only:
+        EmailMessage(
+            title,
+            render_to_string(template, context=context, request=request, using="AUTOESCAPE_OFF"),
+            settings.DEFAULT_FROM_EMAIL,
+            [admin[1] for admin in settings.ADMINS]
+        ).send(fail_silently=False)
+    else:
+        # Use a special reply-to address to avoid Freshdesk's filters: a ticket will be opened.
+        EmailMessage(
+            title,
+            render_to_string(template, context=context, request=request, using="AUTOESCAPE_OFF"),
+            settings.DEFAULT_FROM_EMAIL,
+            [settings.DEFAULT_FROM_EMAIL],
+            headers={'Reply-To': settings.DEFAULT_REPLYTO_EMAIL}
+        ).send(fail_silently=False)

--- a/perma-payments/perma_payments/tests/test_email.py
+++ b/perma-payments/perma_payments/tests/test_email.py
@@ -1,4 +1,5 @@
 from django.http import HttpRequest
+from django.test.utils import override_settings
 
 import pytest
 
@@ -20,6 +21,7 @@ def test_send_self_email(email, mailoutbox):
     assert m.from_email == settings.DEFAULT_FROM_EMAIL
     assert m.to == [settings.ADMINS[0][1]]
 
+@override_settings(DEFAULT_REPLYTO_EMAIL='from@example.com')
 def test_send_self_email_everybody(email, mailoutbox):
     send_self_email(email['subject'], HttpRequest(), context={'message': email['message']}, devs_only=False)
     assert len(mailoutbox) == 1
@@ -27,7 +29,8 @@ def test_send_self_email_everybody(email, mailoutbox):
     assert m.subject == email['subject']
     assert m.body == email['message'] + "\n"
     assert m.from_email == settings.DEFAULT_FROM_EMAIL
-    assert m.to == [settings.DEFAULT_REPLYTO_EMAIL]
+    assert m.to == [settings.DEFAULT_FROM_EMAIL]
+    assert m.reply_to == ['from@example.com']
 
 
 def test_send_self_email_template(email, mocker):

--- a/perma-payments/perma_payments/tests/test_email.py
+++ b/perma-payments/perma_payments/tests/test_email.py
@@ -8,22 +8,30 @@ from perma_payments.email import *
 def email():
     return {
        'subject': 'the subject',
-       'message': 'the message',
-       'from': 'from@example.com'
+       'message': 'the message'
     }
 
-def test_send_admin_email(email, mailoutbox):
-    send_admin_email(email['subject'], email['from'], HttpRequest(), context={'message': email['message']})
+def test_send_self_email(email, mailoutbox):
+    send_self_email(email['subject'], HttpRequest(), context={'message': email['message']})
     assert len(mailoutbox) == 1
     m = mailoutbox[0]
     assert m.subject == email['subject']
     assert m.body == email['message'] + "\n"
     assert m.from_email == settings.DEFAULT_FROM_EMAIL
-    assert m.reply_to == [email['from']]
+    assert m.to == [settings.ADMINS[0][1]]
+
+def test_send_self_email_everybody(email, mailoutbox):
+    send_self_email(email['subject'], HttpRequest(), context={'message': email['message']}, devs_only=False)
+    assert len(mailoutbox) == 1
+    m = mailoutbox[0]
+    assert m.subject == email['subject']
+    assert m.body == email['message'] + "\n"
+    assert m.from_email == settings.DEFAULT_FROM_EMAIL
+    assert m.to == [settings.DEFAULT_REPLYTO_EMAIL]
 
 
-def test_send_admin_email_template(email, mocker):
+def test_send_self_email_template(email, mocker):
     stringified = mocker.patch('perma_payments.email.render_to_string', autospec=True)
     request = HttpRequest()
-    send_admin_email(email['subject'], email['from'], request, template="test")
-    stringified.assert_called_once_with("test", context={}, request=request)
+    send_self_email(email['subject'], request, template="test")
+    stringified.assert_called_once_with("test", context={}, request=request, using='AUTOESCAPE_OFF')

--- a/perma-payments/perma_payments/tests/test_routes.py
+++ b/perma-payments/perma_payments/tests/test_routes.py
@@ -850,7 +850,7 @@ def test_cancel_request_post_subscription_happy_path(client, cancel_request, com
         return_value=complete_standing_sa
     )
     can_be_altered = mocker.patch.object(complete_standing_sa, 'can_be_altered', return_value=True)
-    email = mocker.patch('perma_payments.views.send_admin_email', autospec=True)
+    email = mocker.patch('perma_payments.views.send_self_email', autospec=True)
     log = mocker.patch('perma_payments.views.logger.info', autospec=True)
 
     # request
@@ -859,7 +859,6 @@ def test_cancel_request_post_subscription_happy_path(client, cancel_request, com
     # assertions
     assert can_be_altered.call_count == 1
     assert log.call_count == 1
-    assert email.mock_calls[0][1][1] == settings.DEFAULT_FROM_EMAIL
     assert email.mock_calls[0][2]['template'] == "email/cancel.txt"
     assert email.mock_calls[0][2]['context'] == {
         'registrar': cancel_request['valid_data']['registrar'],

--- a/perma-payments/perma_payments/views.py
+++ b/perma-payments/perma_payments/views.py
@@ -20,7 +20,7 @@ from .constants import (
     CS_TOKEN_UPDATE_URL
 )
 from .custom_errors import bad_request
-from .email import send_admin_email
+from .email import send_self_email
 from .models import (
     SubscriptionAgreement,
     OutgoingTransaction,
@@ -415,7 +415,7 @@ def cancel_request(request):
         'merchant_reference_number': sa.subscription_request.reference_number
     }
     logger.info("Cancellation request received from registrar {} for {}".format(registrar, context['merchant_reference_number']))
-    send_admin_email('ACTION REQUIRED: cancellation request received', settings.DEFAULT_FROM_EMAIL, request, template="email/cancel.txt", context=context)
+    send_self_email('ACTION REQUIRED: cancellation request received', request, template="email/cancel.txt", context=context, devs_only=False)
     sa.cancellation_requested = True
     sa.save(update_fields=['cancellation_requested'])
     return redirect(settings.PERMA_SUBSCRIPTION_CANCELED_REDIRECT_URL)


### PR DESCRIPTION
Behaves the same as Perma does.

Cancellation requests are sent to the main Perma email and, we hope, will generate a support ticket. The nightly emails will generate a support ticket only if there are still pending cancellation requests. If there are not pending cancellation requests, settings.ADMINS will receive the notice so they can feel confident the system is working.