### PR TITLE
Don't html encode special entities in emails.

### DIFF
--- a/perma-payments/perma_payments/email.py
+++ b/perma-payments/perma_payments/email.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from django.core.mail import EmailMessage
-from django.template.loader import render_to_string
+from django.template import RequestContext, engines
 
 
 def send_self_email(title, request, template="email/default.txt", context={}, devs_only=True):
@@ -8,10 +8,19 @@ def send_self_email(title, request, template="email/default.txt", context={}, de
         Send a message to ourselves. By default, sends only to settings.ADMINS.
         To contact the main Perma email address, set devs_only=False
     """
+    # load the django template engine directly, so that we can
+    # pass in a Context/RequestContext object with autocomplete=False
+    # https://docs.djangoproject.com/en/1.11/topics/templates/#django.template.loader.engines
+    #
+    # (though render and render_to_string take a "context" kwarg of type dict,
+    #  that dict cannot be used to configure autoescape, but only to pass keys/values to the template)
+    engine = engines['django'].engine
+    email_text = engine.get_template(template).render(RequestContext(request, context, autoescape=False))
+
     if devs_only:
         EmailMessage(
             title,
-            render_to_string(template, context=context, request=request),
+            email_text,
             settings.DEFAULT_FROM_EMAIL,
             [admin[1] for admin in settings.ADMINS]
         ).send(fail_silently=False)
@@ -19,7 +28,7 @@ def send_self_email(title, request, template="email/default.txt", context={}, de
         # Use a special reply-to address to avoid Freshdesk's filters: a ticket will be opened.
         EmailMessage(
             title,
-            render_to_string(template, context=context, request=request),
+            email_text,
             settings.DEFAULT_FROM_EMAIL,
             [settings.DEFAULT_FROM_EMAIL],
             reply_to=[settings.DEFAULT_REPLYTO_EMAIL]

--- a/perma-payments/perma_payments/tests/test_email.py
+++ b/perma-payments/perma_payments/tests/test_email.py
@@ -10,7 +10,7 @@ from perma_payments.email import send_self_email
 def email():
     return {
        'subject': 'the subject',
-       'message': 'the message'
+       'message': "the message has an apostrophe in it: '"
     }
 
 def test_send_self_email(email, mailoutbox):
@@ -32,10 +32,3 @@ def test_send_self_email_everybody(email, mailoutbox):
     assert m.from_email == settings.DEFAULT_FROM_EMAIL
     assert m.to == [settings.DEFAULT_FROM_EMAIL]
     assert m.reply_to == ['from@example.com']
-
-
-def test_send_self_email_template(email, mocker):
-    stringified = mocker.patch('perma_payments.email.render_to_string', autospec=True)
-    request = HttpRequest()
-    send_self_email(email['subject'], request, template="test")
-    stringified.assert_called_once_with("test", context={}, request=request)


### PR DESCRIPTION
What do you think of this approach?