### PR TITLE
Move purchase history to its own route.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: postgres:9.6.2
   web:
     build: ./perma-payments
-    image: perma-payments:0.25
+    image: perma-payments:0.26
     tty: true
     command: bash
     volumes:

--- a/perma-payments/perma_payments/urls.py
+++ b/perma-payments/perma_payments/urls.py
@@ -8,6 +8,7 @@ urlpatterns = [
     url(r'^cybersource-callback/$', views.cybersource_callback, name='cybersource_callback'),
     url(r'^purchase/$', views.purchase, name='purchase'),
     url(r'^acknowledge-purchase/$', views.acknowledge_purchase, name='acknowledge_purchase'),
+    url(r'^purchase-history/$', views.purchase_history, name='purchase_history'),
     url(r'^subscribe/$', views.subscribe, name='subscribe'),
     url(r'^subscription/$', views.subscription, name='subscription'),
     url(r'^update-statuses/$', views.update_statuses, name='update_statuses'),


### PR DESCRIPTION
It was a bad idea to return purchase history along with subscription info.... The idea was to avoid an extra network request on the `/settings/usage-plan` page in Perma, but the fallout was ridiculous: extensive changes to existing code, all of which were inelegant, and a weird API. 

This is much cleaner.