### PR TITLE
Rek run pp perma

### DIFF
--- a/web/perma_payments/models.py
+++ b/web/perma_payments/models.py
@@ -440,6 +440,17 @@ class SubscriptionRequest(OutgoingTransaction, SubscriptionFields):
         )
     )
 
+    @classmethod
+    def select_subscription_reference(cls, sa_id):
+        sub_request = SubscriptionRequest.objects.get(subscription_agreement_id=sa_id)
+
+        if sub_request:
+            return sub_request.reference_number
+        else:
+            logger.error()
+            if settings.RAISE_IF_SUBSCRIPTION_NOT_FOUND:
+                raise cls.ObjectDoesNotExist
+
     def get_formatted_start_date(self):
         """
         Returns the recurring_start_date in the format required by CyberSource
@@ -736,7 +747,8 @@ class PurchaseRequestResponse(Response):
             {
                 'id': purchase.pk,
                 'link_quantity': purchase.related_request.link_quantity,
-                'date': purchase.related_request.request_datetime
+                'date': purchase.related_request.request_datetime,
+                'reference_number': purchase.related_request.reference_number,
             } for purchase in purchases
         ]
 

--- a/web/perma_payments/models.py
+++ b/web/perma_payments/models.py
@@ -440,17 +440,6 @@ class SubscriptionRequest(OutgoingTransaction, SubscriptionFields):
         )
     )
 
-    @classmethod
-    def select_subscription_reference(cls, sa_id):
-        sub_request = SubscriptionRequest.objects.get(subscription_agreement_id=sa_id)
-
-        if sub_request:
-            return sub_request.reference_number
-        else:
-            logger.error()
-            if settings.RAISE_IF_SUBSCRIPTION_NOT_FOUND:
-                raise cls.ObjectDoesNotExist
-
     def get_formatted_start_date(self):
         """
         Returns the recurring_start_date in the format required by CyberSource

--- a/web/perma_payments/tests/test_routes.py
+++ b/web/perma_payments/tests/test_routes.py
@@ -119,7 +119,6 @@ def subscribe():
             'recurring_start_date': SENTINEL['date'],
             'link_limit': SENTINEL['link_limit'],
             'link_limit_effective_timestamp': SENTINEL['datetime'].timestamp(),
-            'reference_number': SENTINEL['reference_number']
         }
     }
     for field in FIELDS_REQUIRED_FROM_PERMA['subscribe']:

--- a/web/perma_payments/tests/test_routes.py
+++ b/web/perma_payments/tests/test_routes.py
@@ -118,7 +118,8 @@ def subscribe():
             'recurring_frequency': SENTINEL['recurring_frequency'],
             'recurring_start_date': SENTINEL['date'],
             'link_limit': SENTINEL['link_limit'],
-            'link_limit_effective_timestamp': SENTINEL['datetime'].timestamp()
+            'link_limit_effective_timestamp': SENTINEL['datetime'].timestamp(),
+            'reference_number': SENTINEL['reference_number']
         }
     }
     for field in FIELDS_REQUIRED_FROM_PERMA['subscribe']:
@@ -1371,6 +1372,7 @@ def test_subscription_post_standard_standing_subscription(client, subscription, 
             'frequency': complete_standing_sa.current_frequency,
             'status': complete_standing_sa.status,
             'paid_through': complete_standing_sa.paid_through,
+            'reference_number': complete_standing_sa.subscription_request.reference_number,
         },
         'timestamp': mocker.sentinel.timestamp,
         'purchases': []
@@ -1474,7 +1476,8 @@ def test_single_purchase_in_history(client, purchase_history, get_prr_for_user, 
     assert purchase_history == [{
         "id": prr.id,
         "link_quantity": prr.related_request.link_quantity,
-        "date": prr.related_request.request_datetime
+        "date": prr.related_request.request_datetime,
+        "reference_number": prr.related_request.reference_number
     }]
 
 
@@ -1494,11 +1497,13 @@ def test_multiple_purchases_in_history(client, purchase_history, get_prr_for_use
     assert purchase_history == [{
         "id": prr1.id,
         "link_quantity": prr1.related_request.link_quantity,
-        "date": prr1.related_request.request_datetime
+        "date": prr1.related_request.request_datetime,
+        "reference_number": prr1.related_request.reference_number
     },{
         "id": prr2.id,
         "link_quantity": prr2.related_request.link_quantity,
-        "date": prr2.related_request.request_datetime
+        "date": prr2.related_request.request_datetime,
+        "reference_number": prr2.related_request.reference_number
     }]
 
 

--- a/web/perma_payments/tests/utils.py
+++ b/web/perma_payments/tests/utils.py
@@ -35,7 +35,8 @@ SENTINEL = {
     'message': fake.sentence(nb_words=7),
     'payment_token': fake.password(length=26),
     'invalid_payment_token': fake.password(length=16),
-    'purchase_pk': fake.random_int()
+    'purchase_pk': fake.random_int(),
+    'reference_number': f'PERMA-{fake.random_int(min=1000, max=9999)}-{fake.random_int(min=1000, max=9999)}'
 }
 
 

--- a/web/perma_payments/tests/utils.py
+++ b/web/perma_payments/tests/utils.py
@@ -35,8 +35,7 @@ SENTINEL = {
     'message': fake.sentence(nb_words=7),
     'payment_token': fake.password(length=26),
     'invalid_payment_token': fake.password(length=16),
-    'purchase_pk': fake.random_int(),
-    'reference_number': f'PERMA-{fake.random_int(min=1000, max=9999)}-{fake.random_int(min=1000, max=9999)}'
+    'purchase_pk': fake.random_int()
 }
 
 

--- a/web/perma_payments/views.py
+++ b/web/perma_payments/views.py
@@ -598,8 +598,8 @@ def subscription(request):
     standing_subscription = SubscriptionAgreement.customer_standing_subscription(data['customer_pk'], data['customer_type'])
     if not standing_subscription:
         subscription = None
+        subscriptionReference = None
     else:
-
         subscription = {
             'link_limit': standing_subscription.current_link_limit,
             'link_limit_effective_timestamp': formatted_date_or_none(standing_subscription.current_link_limit_effective_timestamp),
@@ -607,6 +607,7 @@ def subscription(request):
             'frequency': standing_subscription.current_frequency,
             'paid_through': formatted_date_or_none(standing_subscription.paid_through),
         }
+        subscriptionReference = SubscriptionRequest.select_subscription_reference(standing_subscription.id)
 
         if standing_subscription.cancellation_requested and standing_subscription.status != 'Canceled':
             subscription['status'] = 'Cancellation Requested'
@@ -615,13 +616,13 @@ def subscription(request):
 
     # Mention any bonus links that have been purchased, but not yet acknowledged
     purchases = PurchaseRequestResponse.customer_unacknowledged(data['customer_pk'], data['customer_type'])
-
     response = {
         'customer_pk': data['customer_pk'],
         'customer_type': data['customer_type'],
         'subscription': subscription,
         'timestamp': datetime.utcnow().timestamp(),
-        'purchases': purchases
+        'purchases': purchases,
+        'reference_number': subscriptionReference
     }
     return JsonResponse({'encrypted_data': prep_for_perma(response).decode('ascii')})
 

--- a/web/perma_payments/views.py
+++ b/web/perma_payments/views.py
@@ -599,6 +599,7 @@ def subscription(request):
     if not standing_subscription:
         subscription = None
         subscriptionReference = None
+
     else:
         subscription = {
             'link_limit': standing_subscription.current_link_limit,
@@ -616,6 +617,7 @@ def subscription(request):
 
     # Mention any bonus links that have been purchased, but not yet acknowledged
     purchases = PurchaseRequestResponse.customer_unacknowledged(data['customer_pk'], data['customer_type'])
+
     response = {
         'customer_pk': data['customer_pk'],
         'customer_type': data['customer_type'],

--- a/web/perma_payments/views.py
+++ b/web/perma_payments/views.py
@@ -598,7 +598,6 @@ def subscription(request):
     standing_subscription = SubscriptionAgreement.customer_standing_subscription(data['customer_pk'], data['customer_type'])
     if not standing_subscription:
         subscription = None
-
     else:
         subscription = {
             'link_limit': standing_subscription.current_link_limit,
@@ -608,6 +607,7 @@ def subscription(request):
             'paid_through': formatted_date_or_none(standing_subscription.paid_through),
             'reference_number': standing_subscription.subscription_request.reference_number
         }
+
         if standing_subscription.cancellation_requested and standing_subscription.status != 'Canceled':
             subscription['status'] = 'Cancellation Requested'
         else:
@@ -621,7 +621,7 @@ def subscription(request):
         'customer_type': data['customer_type'],
         'subscription': subscription,
         'timestamp': datetime.utcnow().timestamp(),
-        'purchases': purchases,
+        'purchases': purchases
     }
     return JsonResponse({'encrypted_data': prep_for_perma(response).decode('ascii')})
 

--- a/web/perma_payments/views.py
+++ b/web/perma_payments/views.py
@@ -598,7 +598,6 @@ def subscription(request):
     standing_subscription = SubscriptionAgreement.customer_standing_subscription(data['customer_pk'], data['customer_type'])
     if not standing_subscription:
         subscription = None
-        subscriptionReference = None
 
     else:
         subscription = {
@@ -607,9 +606,8 @@ def subscription(request):
             'rate': standing_subscription.current_rate,
             'frequency': standing_subscription.current_frequency,
             'paid_through': formatted_date_or_none(standing_subscription.paid_through),
+            'reference_number': standing_subscription.subscription_request.reference_number
         }
-        subscriptionReference = SubscriptionRequest.select_subscription_reference(standing_subscription.id)
-
         if standing_subscription.cancellation_requested and standing_subscription.status != 'Canceled':
             subscription['status'] = 'Cancellation Requested'
         else:
@@ -624,7 +622,6 @@ def subscription(request):
         'subscription': subscription,
         'timestamp': datetime.utcnow().timestamp(),
         'purchases': purchases,
-        'reference_number': subscriptionReference
     }
     return JsonResponse({'encrypted_data': prep_for_perma(response).decode('ascii')})
 


### PR DESCRIPTION
The fellow to this PR: https://github.com/harvard-lil/perma/pull/3165

This PR appropriately reveals the `reference_number` field on the subscription object to be displayed by the perma repo. It seeks to address this issue: https://github.com/harvard-lil/perma-payments/issues/153