### PR TITLE
Minor version PG upgrade

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 
 services:
   pp-db:
-    image: registry.lil.tools/library/postgres:12.8
+    image: registry.lil.tools/library/postgres:12.11
     volumes:
       - db_data_12:/var/lib/postgresql/data:delegated
     environment:


### PR DESCRIPTION
Our stage and prod DB instances have "Auto minor version upgrade" enabled, and have made it from 12.8 to 12.11.

https://www.postgresql.org/docs/release/12.11/