### PR TITLE
Add GET method to purchase/ and subscribe/

### DIFF
--- a/web/perma_payments/tests/test_routes.py
+++ b/web/perma_payments/tests/test_routes.py
@@ -475,8 +475,13 @@ def test_purchase_post_redirect_form_populated_correctly(client, purchase, purch
 
 
 def test_purchase_other_methods(client, purchase):
-    get_not_allowed(client, purchase['route'])
     put_patch_delete_not_allowed(client, purchase['route'])
+
+
+def test_purchase_get(client, purchase, index):
+    response = client.get(purchase['route'])
+    assert response.status_code == 200
+    expected_template_used(response, index['template'])
 
 
 # acknowledge-purchase
@@ -742,8 +747,13 @@ def test_subscribe_post_redirect_form_populated_correctly(client, subscribe, sub
 
 
 def test_subscribe_other_methods(client, subscribe):
-    get_not_allowed(client, subscribe['route'])
     put_patch_delete_not_allowed(client, subscribe['route'])
+
+
+def test_subscribe_get(client, subscribe, index):
+    response = client.get(subscribe['route'])
+    assert response.status_code == 200
+    expected_template_used(response, index['template'])
 
 
 # change

--- a/web/perma_payments/views.py
+++ b/web/perma_payments/views.py
@@ -236,13 +236,19 @@ def index(request):
 
 
 @csrf_exempt
-@require_http_methods(["POST"])
+@require_http_methods(["GET", "POST"])
 @sensitive_post_parameters('encrypted_data')
 def purchase(request):
     """
     Processes user-initiated one-time purchase requests from Perma.cc;
     Redirects user to CyberSource for payment.
     """
+    if request.method == "GET":
+        return render(request, 'generic.html', {
+            'heading': "Perma Payments",
+            'message': "A window to CyberSource Secure Acceptance Web/Mobile"
+        })
+
     try:
         data = process_perma_transmission(request.POST, FIELDS_REQUIRED_FROM_PERMA['purchase'])
     except InvalidTransmissionException:
@@ -316,13 +322,19 @@ def acknowledge_purchase(request):
 
 
 @csrf_exempt
-@require_http_methods(["POST"])
+@require_http_methods(["GET", "POST"])
 @sensitive_post_parameters('encrypted_data')
 def subscribe(request):
     """
     Processes user-initiated subscription requests from Perma.cc;
     Redirects user to CyberSource for payment.
     """
+    if request.method == "GET":
+        return render(request, 'generic.html', {
+            'heading': "Perma Payments",
+            'message': "A window to CyberSource Secure Acceptance Web/Mobile"
+        })
+    
     try:
         data = process_perma_transmission(request.POST, FIELDS_REQUIRED_FROM_PERMA['subscribe'])
     except InvalidTransmissionException:


### PR DESCRIPTION
This reuses the template for the index page; there could be an argument for returning JSON, or plain text, but this was simple to implement and test.