### PR TITLE
Update sqlparse

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,5 +1,4 @@
 # overrides for local development, not used in CI
-version: '3'
 services:
   web:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '2'
-
 services:
   pp-db:
     image: registry.lil.tools/library/postgres:12.11

--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -359,9 +359,9 @@ sortedcontainers==2.4.0 \
     --hash=sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88 \
     --hash=sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0
     # via hypothesis
-sqlparse==0.4.4 \
-    --hash=sha256:5430a4fe2ac7d0f93e66f1efc6e1338a41884b7ddf2a350cedd20ccc4d9d28f3 \
-    --hash=sha256:d446183e84b8349fa3061f0fe7f06ca94ba65b426946ffebe6e3e8295332420c
+sqlparse==0.5.0 \
+    --hash=sha256:714d0a4932c059d16189f58ef5411ec2287a4360f17cdd0edd2d09d4c5087c93 \
+    --hash=sha256:c204494cd97479d0e39f28c93d46c0b2d5959c7b9ab904762ea6c7af211c8663
     # via django
 typing-extensions==4.9.0 \
     --hash=sha256:23478f88c37f27d76ac8aee6c905017a143b0b1b886c3c9f66bc2fd94f9f5783 \


### PR DESCRIPTION
https://github.com/andialbrecht/sqlparse/blob/master/CHANGELOG

This PR also removes version from the docker compose files; after seeing 'version' is obsolete, I found [this](https://github.com/compose-spec/compose-spec/blob/master/spec.md#version-and-name-top-level-elements).