### PR TITLE
Minimal upgrade to Postgres 16

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,8 @@
 services:
   pp-db:
-    image: registry.lil.tools/library/postgres:12.11
+    image: registry.lil.tools/library/postgres:16.6
     volumes:
-      - db_data_12:/var/lib/postgresql/data:delegated
+      - db_data_16:/var/lib/postgresql/data:delegated
     environment:
       - POSTGRES_PASSWORD=example
   web:
@@ -27,6 +27,7 @@ services:
 
 volumes:
   db_data_12:
+  db_data_16:
 
 networks:
   default:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,6 @@ services:
           - 'perma-payments'
 
 volumes:
-  db_data_12:
   db_data_16:
 
 networks:


### PR DESCRIPTION
Tests pass locally.

See the PG release notes for versions [13](https://www.postgresql.org/docs/13/release-13.html), [14](https://www.postgresql.org/docs/14/release.html), [15](https://www.postgresql.org/docs/15/release.html), and [16](https://www.postgresql.org/docs/16/release.html).

The RDS upgrade path from 12.19, which is what we are running now, does not extend directly to 16.6, so I took the liberty of upgrading our stage instance from 12.19 to 12.22, and then to 16.6; we can kick the tires on stage. The upgrades took some minutes; we'll go into maintenance mode when it's time to upgrade the production instances.

