### PR TITLE
Alter monthly expectations

### DIFF
--- a/web/config/settings/settings_base.py
+++ b/web/config/settings/settings_base.py
@@ -164,8 +164,8 @@ RAISE_IF_MULTIPLE_SUBSCRIPTIONS_FOUND = True
 # Perma.cc staff must update subscription statuses again...
 # if 0: tomorrow
 # if 7: within the next week
-# if 31: next month (that is, exactly as usual, as though this never happened)
-GRACE_PERIOD = 31
+# if 31: next month
+GRACE_PERIOD = 7
 
 LOGGING = {
     'version': 1,

--- a/web/perma_payments/models.py
+++ b/web/perma_payments/models.py
@@ -1,4 +1,3 @@
-import calendar
 import datetime
 from dateutil.relativedelta import relativedelta
 import random
@@ -56,16 +55,6 @@ def generate_reference_number():
 
 def is_ref_number_available(rn):
     return not SubscriptionRequest.objects.filter(reference_number=rn).exists() and not PurchaseRequest.objects.filter(reference_number=rn).exists()
-
-
-def last_day_of_month(now):
-    _, num_days = calendar.monthrange(now.year, now.month)
-    return datetime.datetime(now.year, now.month, num_days, tzinfo=now.tzinfo)
-
-
-def this_day_next_year(now):
-    # relativedelta handles leap years: 2/29 -> 2/28
-    return now + relativedelta(years=1)
 
 
 def just_before_midnight(dt):
@@ -202,34 +191,49 @@ class SubscriptionAgreement(SubscriptionAndPurchaseMixin):
 
 
     def calculate_paid_through_date_from_reported_status(self, status):
-        if status == 'Current':
-            frequency = self.current_frequency
-            now = datetime.datetime.now(tz=timezone(settings.TIME_ZONE))
-            if frequency == 'monthly':
-                # Monthly customers are charged on the 1st of the month.
-                # Any 'current' monthly customer is paid through the end of the month.
-                return just_before_midnight(last_day_of_month(now))
-            elif frequency == 'annually':
-                # Annual customers are charged on the anniversary of their subscription date.
-                # If that day has already passed this year:
-                #    a 'current' annual customer is paid through their anniversary, NEXT year.
-                # If that day has not yet passed this year:
-                #    a 'current' annual customer is paid through their anniversary THIS year.
-                # If today is the anniversary:
-                #    we can't know whether CyberSource has attempted a charge yet.
-                #    Customer is paid through today, but tomorrow is a mystery.
-                #    See settings.GRACE_PERIOD for complete discussion
-                anniversary_this_year = self.created_date.replace(year=now.year)
-                if anniversary_this_year < now:
-                    return just_before_midnight(this_day_next_year(anniversary_this_year))
-                elif anniversary_this_year == now:
-                    return just_before_midnight(now + relativedelta(days=settings.GRACE_PERIOD))
-                else:
-                    return just_before_midnight(anniversary_this_year)
+        if status != 'Current':
+            return self.paid_through
+
+        frequency = self.current_frequency
+        now = datetime.datetime.now(tz=timezone(settings.TIME_ZONE))
+        start = self.subscription_request.recurring_start_date
+
+        # `billing_day_this_period` is the date in the current month (for monthly
+        # subscriptions) or current year (for annual subscriptions) on which
+        # CyberSource is scheduled to charge this customer.
+        #
+        # `now` + `relativedelta(day=...)` / `(month=...)` (note: singular)
+        # takes `now` and swaps out the day / month, similar to `datetime.replace(...),
+        # but unlike datetime.replace, clamps out-of-range values to the last valid day of the month.
+        # E.g., A subscription generally billed on the 31st becomes Feb 28 (or 29) in February instead of raising ValueError.
+        if frequency == 'monthly':
+            period = relativedelta(months=1)
+            billing_day_this_period = now + relativedelta(day=start.day)
+        elif frequency == 'annually':
+            period = relativedelta(years=1)
+            billing_day_this_period = now + relativedelta(month=start.month, day=start.day)
+        else:
             # We only offer monthly and annual subscriptions.
-            # If we change our minds, we need more logic here.
+            # If that ever changes, add another branch above.
             logger.error("No code for calculating paid-through date for subscriptions recurring {}".format(frequency))
-        return self.paid_through
+            return self.paid_through
+
+        if billing_day_this_period.date() < now.date():
+            # This period's billing day has already passed, so CyberSource has
+            # charged the customer for the current period. They are paid through
+            # the next period's billing day.
+            return just_before_midnight(billing_day_this_period + period)
+        elif billing_day_this_period.date() == now.date():
+            # Today IS the billing day. We can't know whether CyberSource has
+            # attempted today's charge yet, so be conservative: credit the customer
+            # through today plus settings.GRACE_PERIOD days, giving staff time to
+            # re-run the status check once CyberSource has confirmed the result.
+            # See settings.GRACE_PERIOD for the full discussion.
+            return just_before_midnight(now + relativedelta(days=settings.GRACE_PERIOD))
+        else:
+            # This period's billing day is still upcoming; the customer is paid
+            # through that date.
+            return just_before_midnight(billing_day_this_period)
 
 
     def update_after_cs_decision(self, request, decision, redacted_response):

--- a/web/perma_payments/tests/test_models.py
+++ b/web/perma_payments/tests/test_models.py
@@ -17,6 +17,7 @@ from perma_payments.models import (STANDING_STATUSES, REFERENCE_NUMBER_PREFIX,
 
 from .utils import GENESIS, SENTINEL, absent_required_fields_raise_validation_error, autopopulated_fields_present
 
+_UTC = datetime.timezone.utc
 
 #
 # FIXTURES
@@ -312,6 +313,53 @@ def spoof_django_post_object():
     return QueryDict('a=1,b=2,c=3')
 
 
+@pytest.fixture()
+@pytest.mark.django_db
+def make_current_sa():
+    """
+    Factory fixture: returns a callable that builds a 'Current' SubscriptionAgreement
+    (with attached SubscriptionRequest) for a given frequency and recurring_start_date.
+    Useful for tests that need to vary these fields per parametrize case.
+    """
+    def _make(frequency, start_date):
+        sa = SubscriptionAgreement(
+            customer_pk=SENTINEL['customer_pk'],
+            customer_type=SENTINEL['customer_type'],
+            status='Current',
+            current_link_limit=SENTINEL['link_limit'],
+            current_rate=SENTINEL['recurring_amount'],
+            current_frequency=frequency,
+        )
+        sa.save()
+        SubscriptionRequest(
+            subscription_agreement=sa,
+            amount=SENTINEL['amount'],
+            recurring_amount=SENTINEL['recurring_amount'],
+            recurring_start_date=start_date,
+            recurring_frequency=frequency,
+            link_limit=SENTINEL['link_limit'],
+            link_limit_effective_timestamp=GENESIS,
+        ).save()
+        return sa
+    return _make
+
+
+@pytest.fixture()
+def mock_models_now(mocker):
+    """
+    Factory fixture: returns a callable that pins the value returned by
+    `datetime.datetime.now(...)` inside perma_payments.models. We replace the
+    `datetime` attribute on the models module with a MagicMock; the model
+    function under test only uses `datetime.datetime.now(tz=...)`, so this
+    narrow mock is safe.
+    """
+    def _mock(fake_now):
+        fake_dt_module = mocker.MagicMock()
+        fake_dt_module.datetime.now.return_value = fake_now
+        mocker.patch('perma_payments.models.datetime', fake_dt_module)
+    return _mock
+
+
 #
 # TESTS
 #
@@ -506,9 +554,76 @@ def test_sa_update_after_cs_decision_cr(decision, mocker, change_request):
 
 
 @pytest.mark.django_db
-def test_sa_calculate_paid_through_date_annual(complete_current_sa):
-    # lame test just to pass through some of the code
-    assert complete_current_sa.calculate_paid_through_date_from_reported_status('Current').tzinfo
+def test_sa_calculate_paid_through_date_returns_existing_paid_through_when_not_current(complete_current_sa, mocker):
+    # For any non-'Current' status, the function short-circuits and returns
+    # whatever paid_through is already on the SA, untouched.
+    sentinel = datetime.datetime(2030, 1, 1, tzinfo=timezone(settings.TIME_ZONE))
+    complete_current_sa.paid_through = sentinel
+    for status in ['Hold', 'Pending', 'Canceled', 'Aborted', 'Rejected']:
+        assert complete_current_sa.calculate_paid_through_date_from_reported_status(status) == sentinel
+
+
+@pytest.mark.django_db
+def test_sa_calculate_paid_through_date_unknown_frequency_logs_and_returns_paid_through(complete_current_sa, mocker):
+    log = mocker.patch('perma_payments.models.logger.error', autospec=True)
+    sentinel = datetime.datetime(2030, 1, 1, tzinfo=timezone(settings.TIME_ZONE))
+    complete_current_sa.paid_through = sentinel
+    complete_current_sa.current_frequency = 'weekly'
+    assert complete_current_sa.calculate_paid_through_date_from_reported_status('Current') == sentinel
+    assert log.call_count == 1
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("frequency,start_month,start_day,fake_now,expected", [
+    # --- Monthly ---
+    # Old-style (day=1) queried mid-month: this period's billing day has passed,
+    # so paid through next month's billing day.
+    ('monthly', 1, 1,
+        datetime.datetime(2026, 5, 14, 14, 58, tzinfo=_UTC),
+        datetime.datetime(2026, 6, 1, 23, 59, 59, tzinfo=_UTC)),
+    # New-style (day=20), queried before billing day this month: paid through
+    # this month's billing day.
+    ('monthly', 1, 20,
+        datetime.datetime(2026, 5, 14, 14, 58, tzinfo=_UTC),
+        datetime.datetime(2026, 5, 20, 23, 59, 59, tzinfo=_UTC)),
+    # day=31 in February clamps to Feb 28 (2026 is not a leap year).
+    ('monthly', 1, 31,
+        datetime.datetime(2026, 2, 15, 10, 0, tzinfo=_UTC),
+        datetime.datetime(2026, 2, 28, 23, 59, 59, tzinfo=_UTC)),
+    # --- Annual ---
+    # Anniversary already passed this year: paid through next year's anniversary.
+    ('annually', 8, 15,
+        datetime.datetime(2026, 9, 10, 12, 0, tzinfo=_UTC),
+        datetime.datetime(2027, 8, 15, 23, 59, 59, tzinfo=_UTC)),
+    # Anniversary still upcoming this year: paid through this year's anniversary.
+    ('annually', 8, 15,
+        datetime.datetime(2026, 5, 14, 14, 58, tzinfo=_UTC),
+        datetime.datetime(2026, 8, 15, 23, 59, 59, tzinfo=_UTC)),
+])
+def test_sa_calculate_paid_through_date_past_or_future(
+    make_current_sa, mock_models_now, frequency, start_month, start_day, fake_now, expected
+):
+    sa = make_current_sa(frequency, datetime.date(2024, start_month, start_day))
+    mock_models_now(fake_now)
+    assert sa.calculate_paid_through_date_from_reported_status('Current') == expected
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("frequency,start_month,start_day,fake_now", [
+    # Monthly: today's day-of-month equals the billing day-of-month.
+    ('monthly', 1, 14, datetime.datetime(2026, 5, 14, 14, 58, tzinfo=_UTC)),
+    # Annual: today's month and day equal the billing month and day.
+    ('annually', 5, 14, datetime.datetime(2026, 5, 14, 14, 58, tzinfo=_UTC)),
+])
+def test_sa_calculate_paid_through_date_when_today_is_billing_day_uses_grace_period(
+    make_current_sa, mock_models_now, frequency, start_month, start_day, fake_now
+):
+    sa = make_current_sa(frequency, datetime.date(2024, start_month, start_day))
+    mock_models_now(fake_now)
+    expected = (fake_now + relativedelta(days=settings.GRACE_PERIOD)).replace(
+        hour=23, minute=59, second=59
+    )
+    assert sa.calculate_paid_through_date_from_reported_status('Current') == expected
 
 
 # OutgoingTransaction


### PR DESCRIPTION
Until now, we have always set new monthly subscriptions to start on the 1st of the month, charging a one-time prorated fee on initial setup for the days remaining in the current month.

We plan to switch that: full price on the day you sign up, and then your next payment in a month, whichever day that falls on.

This Perma PR changes that behavior: https://github.com/harvard-lil/perma/pull/3774

This corresponding change to Perma Payments adapts the code, so that now it can correctly calculate the "paid through" date for subscriptions whose billing period does NOT start on the first of the month. It also changes the grace period from 31 to 7 days, for instances where paid through status is ambiguous, per discussion in Slack.

The PR includes new unit tests, testing the calculation of "paid through" more thoroughly than we have done in the past.

I also tested by asking Claude to help me spoof several round trips with Cybersource, using the sample webhook POST stored in the repo, `sample_response_subscribe.txt`. The attached demo script creates a pending subscription agreement/request, and then POSTs back what we would expect to see from Cybersource, and then verifies that the status is updated from 'Pending' to 'Current' and that Perma Payments sets the expected "paid through" date.
[demo_paid_through.py](https://github.com/user-attachments/files/27808139/demo_paid_through.py)

So, even though I have not gone through the whole flow locally (which would require exposing my dev instance using ngrok and reconfiguring our Cybersource test tier to send responses to my laptop instead of to Perma Payments Stage... possible, but annoying), I am pretty confident this works as intended. 

If merged, we can test even without deploying the upstream changes to Perma: this should still work, with the existing Perma code. 