### PR TITLE
Add special handling for the start date of new subscriptions.

### DIFF
--- a/web/perma_payments/models.py
+++ b/web/perma_payments/models.py
@@ -218,7 +218,12 @@ class SubscriptionAgreement(SubscriptionAndPurchaseMixin):
             logger.error("No code for calculating paid-through date for subscriptions recurring {}".format(frequency))
             return self.paid_through
 
-        if billing_day_this_period.date() < now.date():
+        if now.date() == start:
+            # This is a brand new subscription, and CyberSource has
+            # charged the customer for the current period. They are paid through
+            # the next period's billing day.
+            return just_before_midnight(billing_day_this_period + period)
+        elif billing_day_this_period.date() < now.date():
             # This period's billing day has already passed, so CyberSource has
             # charged the customer for the current period. They are paid through
             # the next period's billing day.

--- a/web/perma_payments/tests/test_models.py
+++ b/web/perma_payments/tests/test_models.py
@@ -626,6 +626,27 @@ def test_sa_calculate_paid_through_date_when_today_is_billing_day_uses_grace_per
     assert sa.calculate_paid_through_date_from_reported_status('Current') == expected
 
 
+@pytest.mark.django_db
+@pytest.mark.parametrize("frequency,start_date,fake_now,expected", [
+    # Brand-new subscription: CyberSource just charged for the first period,
+    # so paid through the next billing day (not the grace-period fallback).
+    ('monthly',
+        datetime.date(2026, 5, 14),
+        datetime.datetime(2026, 5, 14, 14, 58, tzinfo=_UTC),
+        datetime.datetime(2026, 6, 14, 23, 59, 59, tzinfo=_UTC)),
+    ('annually',
+        datetime.date(2026, 5, 14),
+        datetime.datetime(2026, 5, 14, 14, 58, tzinfo=_UTC),
+        datetime.datetime(2027, 5, 14, 23, 59, 59, tzinfo=_UTC)),
+])
+def test_sa_calculate_paid_through_date_new_subscription_on_start_day(
+    make_current_sa, mock_models_now, frequency, start_date, fake_now, expected
+):
+    sa = make_current_sa(frequency, start_date)
+    mock_models_now(fake_now)
+    assert sa.calculate_paid_through_date_from_reported_status('Current') == expected
+
+
 # OutgoingTransaction
 
 def test_outgoing_required_fields():


### PR DESCRIPTION
I somehow missed an obvious special case in https://github.com/harvard-lil/perma-payments/pull/194 ... the very moment/day a new subscription is created.

When a subscription is created and CyberSource accepts the first charge on the same day as recurring_start_date, billing_day_this_period lands on today. As currently deployed, that falls into the "today IS the billing day" path and applies the grace-period fallback — even though we know the initial charge just succeeded via update_after_cs_decision.

So you end up with now + GRACE_PERIOD days instead of a full billing period.

<img width="1982" height="782" alt="image" src="https://github.com/user-attachments/assets/57824d43-702b-4a96-a0fa-7ffae512acb8" />

That's not what we want.

This PR fixes that omission.